### PR TITLE
Add basic multi-file playback

### DIFF
--- a/lib/channel1.dart
+++ b/lib/channel1.dart
@@ -3,7 +3,6 @@ import 'package:flutter/material.dart';
 import 'package:player3/settings.dart';
 import 'package:provider/provider.dart';
 import 'channel_model.dart';
-import 'package:provider/provider.dart';
 import 'models/channel_bank_model.dart';
 
 
@@ -15,11 +14,11 @@ class Channel1 extends StatelessWidget {
   Widget build(BuildContext context) {
     final channel = context.watch<ChannelBankModel>().channels[index];
     return Container(
-      key: Key('Channel1_\$id'),
+      key: Key('Channel1_\$index'),
       width: double.infinity,
       padding: const EdgeInsets.all(4),
       decoration: ShapeDecoration(
-        color: context.watch<ChannelBankModel>().channels[index].color,
+        color: channel.color,
 
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(10),
@@ -44,7 +43,7 @@ class Channel1 extends StatelessWidget {
               children: [
                 Text(
                   key: const Key('Name_label'),
-                  context.watch<ChannelBankModel>().channels[index].name,
+                  channel.name,
                   style: const TextStyle(
                     color: Colors.black,
                     fontSize: 16,
@@ -219,42 +218,76 @@ class Channel1 extends StatelessWidget {
               ],
             ),
           ),
-          Container(
-            key: Key('knob_frame'),
-            width: double.infinity,
-            height: 124,
-            clipBehavior: Clip.antiAlias,
-            decoration: const BoxDecoration(),            
-            child: Stack(
-              alignment: Alignment.center,
-              children: [
-                Container(                  
-                  key: Key('knob'),
-                  width: 120,
-                  height: 120,
-                  decoration: ShapeDecoration(
-                    color: const Color(0xFFCBCBCB),
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(17),
+          GestureDetector(
+            onTap: () async {
+              final channel = context.read<ChannelBankModel>().channels[index];
+              final player = channel.player;
+              if (channel.filePath.isEmpty) return;
+              switch (channel.playMode) {
+                case PlayMode.playStop:
+                  if (player.playing) {
+                    await player.stop();
+                    await player.seek(Duration.zero);
+                  } else {
+                    if (player.audioSource == null) {
+                      await player.setFilePath(channel.filePath);
+                    }
+                    await player.play();
+                  }
+                  break;
+                case PlayMode.playPause:
+                  if (player.playing) {
+                    await player.pause();
+                  } else {
+                    if (player.audioSource == null) {
+                      await player.setFilePath(channel.filePath);
+                    }
+                    await player.play();
+                  }
+                  break;
+                case PlayMode.retrigger:
+                  await player.stop();
+                  await player.setFilePath(channel.filePath);
+                  await player.play();
+                  break;
+              }
+            },
+            child: Container(
+              key: const Key('knob_frame'),
+              width: double.infinity,
+              height: 124,
+              clipBehavior: Clip.antiAlias,
+              decoration: const BoxDecoration(),
+              child: Stack(
+                alignment: Alignment.center,
+                children: [
+                  Container(
+                    key: const Key('knob'),
+                    width: 120,
+                    height: 120,
+                    decoration: ShapeDecoration(
+                      color: const Color(0xFFCBCBCB),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(17),
+                      ),
                     ),
                   ),
-                ),
-                
-                Container(
-                  key: Key('knob_label'),
-                  alignment: Alignment.center,
-                  child: Text(
-                    '1',
-                    textAlign: TextAlign.center,
-                    style: TextStyle(
-                      color: Colors.black,
-                      fontSize: 36,
-                      fontFamily: 'Inter',
-                      fontWeight: FontWeight.w400,
+                  Container(
+                    key: const Key('knob_label'),
+                    alignment: Alignment.center,
+                    child: const Text(
+                      '1',
+                      textAlign: TextAlign.center,
+                      style: TextStyle(
+                        color: Colors.black,
+                        fontSize: 36,
+                        fontFamily: 'Inter',
+                        fontWeight: FontWeight.w400,
+                      ),
                     ),
                   ),
-                ),
-              ],
+                ],
+              ),
             ),
           ),
         ],

--- a/lib/models/channel_strip_model.dart
+++ b/lib/models/channel_strip_model.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:just_audio/just_audio.dart';
 
 enum PlayMode {
   playStop,
@@ -14,6 +15,7 @@ class ChannelStripModel {
   Duration startTime;
   Duration stopTime;
   PlayMode playMode;
+  final AudioPlayer player;
 
   ChannelStripModel({
     required this.name,
@@ -23,7 +25,8 @@ class ChannelStripModel {
     required this.startTime,
     required this.stopTime,
     required this.playMode,
-  });
+    AudioPlayer? player,
+  }) : player = player ?? AudioPlayer();
 
   ChannelStripModel copy() {
     return ChannelStripModel(
@@ -34,6 +37,7 @@ class ChannelStripModel {
       startTime: startTime,
       stopTime: stopTime,
       playMode: playMode,
+      player: player,
     );
   }
 }

--- a/lib/settings.dart
+++ b/lib/settings.dart
@@ -550,7 +550,7 @@ String shortenPath(String fullPath, {int maxLength = 40}) {
                                       ),
                                       Expanded(
                                         key: Key('Play_Mode_frame'),
-                                        
+
                                         child: Container(
                                           width: double.infinity,
                                           height: double.infinity,
@@ -561,88 +561,109 @@ String shortenPath(String fullPath, {int maxLength = 40}) {
                                             crossAxisAlignment: CrossAxisAlignment.start,
                                             spacing: 10,
                                             children: [
-                                              Container(
-                                                key: Key('Playstop_btn_frame'),
-                                                height: double.infinity,
-                                                padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 6),
-                                                clipBehavior: Clip.antiAlias,
-                                                decoration: ShapeDecoration(
-                                                  color: const Color(0xFFD9D9D9),
-                                                  shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(4)),
-                                                ),
-                                                child: Column(
-                                                  mainAxisSize: MainAxisSize.min,
-                                                  mainAxisAlignment: MainAxisAlignment.end,
-                                                  crossAxisAlignment: CrossAxisAlignment.center,
-                                                  spacing: 17,
-                                                  children: [
-                                                    Text(
-                                                      'Play/Stop',
-                                                      textAlign: TextAlign.center,
-                                                      style: TextStyle(
-                                                        color: Colors.black,
-                                                        fontSize: 16,
-                                                        fontFamily: 'Inter',
-                                                        fontWeight: FontWeight.w500,
+                                              GestureDetector(
+                                                onTap: () {
+                                                  setState(() {
+                                                    temp.playMode = PlayMode.playStop;
+                                                  });
+                                                },
+                                                child: Container(
+                                                  key: Key('Playstop_btn_frame'),
+                                                  height: double.infinity,
+                                                  padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 6),
+                                                  clipBehavior: Clip.antiAlias,
+                                                  decoration: ShapeDecoration(
+                                                    color: temp.playMode == PlayMode.playStop ? const Color(0xFFB0B0B0) : const Color(0xFFD9D9D9),
+                                                    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(4)),
+                                                  ),
+                                                  child: Column(
+                                                    mainAxisSize: MainAxisSize.min,
+                                                    mainAxisAlignment: MainAxisAlignment.end,
+                                                    crossAxisAlignment: CrossAxisAlignment.center,
+                                                    spacing: 17,
+                                                    children: [
+                                                      const Text(
+                                                        'Play/Stop',
+                                                        textAlign: TextAlign.center,
+                                                        style: TextStyle(
+                                                          color: Colors.black,
+                                                          fontSize: 16,
+                                                          fontFamily: 'Inter',
+                                                          fontWeight: FontWeight.w500,
+                                                        ),
                                                       ),
-                                                    ),
-                                                  ],
+                                                    ],
+                                                  ),
                                                 ),
                                               ),
-                                              Container(
-                                                key: Key('Playpause_btn_frame'),
-                                                height: double.infinity,
-                                                padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 6),
-                                                clipBehavior: Clip.antiAlias,
-                                                decoration: ShapeDecoration(
-                                                  color: const Color(0xFFD9D9D9),
-                                                  shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(4)),
-                                                ),
-                                                child: Column(
-                                                  mainAxisSize: MainAxisSize.min,
-                                                  mainAxisAlignment: MainAxisAlignment.end,
-                                                  crossAxisAlignment: CrossAxisAlignment.center,
-                                                  spacing: 17,
-                                                  children: [
-                                                    Text(
-                                                      'Play/Pause',
-                                                      textAlign: TextAlign.center,
-                                                      style: TextStyle(
-                                                        color: Colors.black,
-                                                        fontSize: 16,
-                                                        fontFamily: 'Inter',
-                                                        fontWeight: FontWeight.w500,
+                                              GestureDetector(
+                                                onTap: () {
+                                                  setState(() {
+                                                    temp.playMode = PlayMode.playPause;
+                                                  });
+                                                },
+                                                child: Container(
+                                                  key: Key('Playpause_btn_frame'),
+                                                  height: double.infinity,
+                                                  padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 6),
+                                                  clipBehavior: Clip.antiAlias,
+                                                  decoration: ShapeDecoration(
+                                                    color: temp.playMode == PlayMode.playPause ? const Color(0xFFB0B0B0) : const Color(0xFFD9D9D9),
+                                                    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(4)),
+                                                  ),
+                                                  child: Column(
+                                                    mainAxisSize: MainAxisSize.min,
+                                                    mainAxisAlignment: MainAxisAlignment.end,
+                                                    crossAxisAlignment: CrossAxisAlignment.center,
+                                                    spacing: 17,
+                                                    children: [
+                                                      const Text(
+                                                        'Play/Pause',
+                                                        textAlign: TextAlign.center,
+                                                        style: TextStyle(
+                                                          color: Colors.black,
+                                                          fontSize: 16,
+                                                          fontFamily: 'Inter',
+                                                          fontWeight: FontWeight.w500,
+                                                        ),
                                                       ),
-                                                    ),
-                                                  ],
+                                                    ],
+                                                  ),
                                                 ),
                                               ),
-                                              Container(
-                                                key: Key('Retrigger_btn_frame'),
-                                                height: double.infinity,
-                                                padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 6),
-                                                clipBehavior: Clip.antiAlias,
-                                                decoration: ShapeDecoration(
-                                                  color: const Color(0xFFD9D9D9),
-                                                  shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(4)),
-                                                ),
-                                                child: Column(
-                                                  mainAxisSize: MainAxisSize.min,
-                                                  mainAxisAlignment: MainAxisAlignment.end,
-                                                  crossAxisAlignment: CrossAxisAlignment.center,
-                                                  spacing: 17,
-                                                  children: [
-                                                    Text(
-                                                      'Retrigger',
-                                                      textAlign: TextAlign.center,
-                                                      style: TextStyle(
-                                                        color: Colors.black,
-                                                        fontSize: 16,
-                                                        fontFamily: 'Inter',
-                                                        fontWeight: FontWeight.w500,
+                                              GestureDetector(
+                                                onTap: () {
+                                                  setState(() {
+                                                    temp.playMode = PlayMode.retrigger;
+                                                  });
+                                                },
+                                                child: Container(
+                                                  key: Key('Retrigger_btn_frame'),
+                                                  height: double.infinity,
+                                                  padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 6),
+                                                  clipBehavior: Clip.antiAlias,
+                                                  decoration: ShapeDecoration(
+                                                    color: temp.playMode == PlayMode.retrigger ? const Color(0xFFB0B0B0) : const Color(0xFFD9D9D9),
+                                                    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(4)),
+                                                  ),
+                                                  child: Column(
+                                                    mainAxisSize: MainAxisSize.min,
+                                                    mainAxisAlignment: MainAxisAlignment.end,
+                                                    crossAxisAlignment: CrossAxisAlignment.center,
+                                                    spacing: 17,
+                                                    children: [
+                                                      const Text(
+                                                        'Retrigger',
+                                                        textAlign: TextAlign.center,
+                                                        style: TextStyle(
+                                                          color: Colors.black,
+                                                          fontSize: 16,
+                                                          fontFamily: 'Inter',
+                                                          fontWeight: FontWeight.w500,
+                                                        ),
                                                       ),
-                                                    ),
-                                                  ],
+                                                    ],
+                                                  ),
                                                 ),
                                               ),
                                             ],

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,6 +32,7 @@ dependencies:
     sdk: flutter
   provider: ^6.1.2
   file_picker: ^6.1.1
+  just_audio: ^0.9.36
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8


### PR DESCRIPTION
## Summary
- integrate `just_audio` package
- store an `AudioPlayer` in `ChannelStripModel`
- handle knob taps to play/stop/pause/retrigger depending on play mode

## Testing
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846b59bf11c8331aaa821fc0c0ba488