### PR TITLE
Implement playback range editing

### DIFF
--- a/lib/channel1.dart
+++ b/lib/channel1.dart
@@ -2,9 +2,17 @@
 import 'package:flutter/material.dart';
 import 'package:player3/settings.dart';
 import 'package:provider/provider.dart';
-import 'channel_model.dart';
-import 'package:provider/provider.dart';
 import 'models/channel_bank_model.dart';
+import 'models/channel_strip_model.dart';
+import 'package:just_audio/just_audio.dart';
+
+String formatDuration(Duration d) {
+  String twoDigits(int n) => n.toString().padLeft(2, '0');
+  final h = twoDigits(d.inHours);
+  final m = twoDigits(d.inMinutes.remainder(60));
+  final s = twoDigits(d.inSeconds.remainder(60));
+  return '$h:$m:$s';
+}
 
 
 class Channel1 extends StatelessWidget {
@@ -15,11 +23,11 @@ class Channel1 extends StatelessWidget {
   Widget build(BuildContext context) {
     final channel = context.watch<ChannelBankModel>().channels[index];
     return Container(
-      key: Key('Channel1_\$id'),
+      key: Key('Channel1_\$index'),
       width: double.infinity,
       padding: const EdgeInsets.all(4),
       decoration: ShapeDecoration(
-        color: context.watch<ChannelBankModel>().channels[index].color,
+        color: channel.color,
 
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(10),
@@ -44,7 +52,7 @@ class Channel1 extends StatelessWidget {
               children: [
                 Text(
                   key: const Key('Name_label'),
-                  context.watch<ChannelBankModel>().channels[index].name,
+                  channel.name,
                   style: const TextStyle(
                     color: Colors.black,
                     fontSize: 16,
@@ -197,9 +205,9 @@ class Channel1 extends StatelessWidget {
               crossAxisAlignment: CrossAxisAlignment.center,
               children: [
                 Text(
-                  key: Key('Start_timecode'),
-                  '00:00:00:00',
-                  style: TextStyle(
+                  key: const Key('Start_timecode'),
+                  formatDuration(channel.startTime),
+                  style: const TextStyle(
                     color: Colors.black,
                     fontSize: 16,
                     fontFamily: 'Inter',
@@ -207,9 +215,9 @@ class Channel1 extends StatelessWidget {
                   ),
                 ),
                 Text(
-                  key: Key('Stop_timecode'),
-                  '03:18:24:05',
-                  style: TextStyle(
+                  key: const Key('Stop_timecode'),
+                  formatDuration(channel.stopTime),
+                  style: const TextStyle(
                     color: Colors.black,
                     fontSize: 16,
                     fontFamily: 'Inter',
@@ -219,42 +227,90 @@ class Channel1 extends StatelessWidget {
               ],
             ),
           ),
-          Container(
-            key: Key('knob_frame'),
-            width: double.infinity,
-            height: 124,
-            clipBehavior: Clip.antiAlias,
-            decoration: const BoxDecoration(),            
-            child: Stack(
-              alignment: Alignment.center,
-              children: [
-                Container(                  
-                  key: Key('knob'),
-                  width: 120,
-                  height: 120,
-                  decoration: ShapeDecoration(
-                    color: const Color(0xFFCBCBCB),
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(17),
+          GestureDetector(
+            onTap: () async {
+              final channel = context.read<ChannelBankModel>().channels[index];
+              final player = channel.player;
+              if (channel.filePath.isEmpty) return;
+
+              Future<void> loadSource() async {
+                await player.setAudioSource(
+                  ClippingAudioSource(
+                    start: channel.startTime,
+                    end: channel.stopTime,
+                    child: AudioSource.file(channel.filePath),
+                  ),
+                );
+              }
+
+              switch (channel.playMode) {
+                case PlayMode.playStop:
+                  if (player.playing) {
+                    await player.stop();
+                    await player.seek(channel.startTime);
+                  } else {
+                    if (player.audioSource == null) {
+                      await loadSource();
+                    } else {
+                      await player.seek(channel.startTime);
+                    }
+                    await player.play();
+                  }
+                  break;
+                case PlayMode.playPause:
+                  if (player.playing) {
+                    await player.pause();
+                  } else {
+                    if (player.audioSource == null) {
+                      await loadSource();
+                    }
+                    await player.seek(channel.startTime);
+                    await player.play();
+                  }
+                  break;
+                case PlayMode.retrigger:
+                  await player.stop();
+                  await loadSource();
+                  await player.play();
+                  break;
+              }
+            },
+            child: Container(
+              key: const Key('knob_frame'),
+              width: double.infinity,
+              height: 124,
+              clipBehavior: Clip.antiAlias,
+              decoration: const BoxDecoration(),
+              child: Stack(
+                alignment: Alignment.center,
+                children: [
+                  Container(
+                    key: const Key('knob'),
+                    width: 120,
+                    height: 120,
+                    decoration: ShapeDecoration(
+                      color: const Color(0xFFCBCBCB),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(17),
+                      ),
                     ),
                   ),
-                ),
-                
-                Container(
-                  key: Key('knob_label'),
-                  alignment: Alignment.center,
-                  child: Text(
-                    '1',
-                    textAlign: TextAlign.center,
-                    style: TextStyle(
-                      color: Colors.black,
-                      fontSize: 36,
-                      fontFamily: 'Inter',
-                      fontWeight: FontWeight.w400,
+                  Container(
+                    key: const Key('knob_label'),
+                    alignment: Alignment.center,
+                    child: const Text(
+                      '1',
+                      textAlign: TextAlign.center,
+                      style: TextStyle(
+                        color: Colors.black,
+                        fontSize: 36,
+                        fontFamily: 'Inter',
+                        fontWeight: FontWeight.w400,
+                      ),
                     ),
                   ),
-                ),
-              ],
+                ],
+              ),
             ),
           ),
         ],

--- a/lib/models/channel_strip_model.dart
+++ b/lib/models/channel_strip_model.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:just_audio/just_audio.dart';
 
 enum PlayMode {
   playStop,
@@ -14,6 +15,7 @@ class ChannelStripModel {
   Duration startTime;
   Duration stopTime;
   PlayMode playMode;
+  final AudioPlayer player;
 
   ChannelStripModel({
     required this.name,
@@ -23,7 +25,8 @@ class ChannelStripModel {
     required this.startTime,
     required this.stopTime,
     required this.playMode,
-  });
+    AudioPlayer? player,
+  }) : player = player ?? AudioPlayer();
 
   ChannelStripModel copy() {
     return ChannelStripModel(
@@ -34,6 +37,7 @@ class ChannelStripModel {
       startTime: startTime,
       stopTime: stopTime,
       playMode: playMode,
+      player: player,
     );
   }
 }

--- a/lib/settings.dart
+++ b/lib/settings.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'channel_model.dart';
 import 'models/channel_strip_model.dart';
 import 'models/channel_bank_model.dart';
 import 'package:file_picker/file_picker.dart';
+import 'package:mask_text_input_formatter/mask_text_input_formatter.dart';
 
 class SettingsWindow extends StatefulWidget {
   final int index;
@@ -16,6 +16,9 @@ class SettingsWindow extends StatefulWidget {
 class _SettingsWindowState extends State<SettingsWindow> {
   late ChannelStripModel temp;
   late TextEditingController _nameController;
+  late TextEditingController _startController;
+  late TextEditingController _endController;
+  final timeFormatter = MaskTextInputFormatter(mask: '##:##:##', filter: {'#': RegExp(r'[0-9]')});
   final Map<String, Color> colorOptions = {
   'None': Colors.grey,
   'Red': Colors.red,
@@ -33,17 +36,38 @@ String shortenPath(String fullPath, {int maxLength = 40}) {
   if (keepLength < 0) return '.../$fileName';
   return '...${fullPath.substring(fullPath.length - keepLength - fileName.length)}';
 }
+
+String formatDuration(Duration d) {
+  String twoDigits(int n) => n.toString().padLeft(2, '0');
+  final h = twoDigits(d.inHours);
+  final m = twoDigits(d.inMinutes.remainder(60));
+  final s = twoDigits(d.inSeconds.remainder(60));
+  return '$h:$m:$s';
+}
+
+Duration parseDuration(String text) {
+  final parts = text.split(':');
+  if (parts.length != 3) return Duration.zero;
+  final h = int.tryParse(parts[0]) ?? 0;
+  final m = int.tryParse(parts[1]) ?? 0;
+  final s = int.tryParse(parts[2]) ?? 0;
+  return Duration(hours: h, minutes: m, seconds: s);
+}
   @override
   void initState() {
     super.initState();
     final original = context.read<ChannelBankModel>().channels[widget.index];
     temp = original.copy();
     _nameController = TextEditingController(text: temp.name);
+    _startController = TextEditingController(text: formatDuration(temp.startTime));
+    _endController = TextEditingController(text: formatDuration(temp.stopTime));
   }
 
   @override
   void dispose() {
     _nameController.dispose();
+    _startController.dispose();
+    _endController.dispose();
     super.dispose();
   }
 
@@ -511,12 +535,17 @@ String shortenPath(String fullPath, {int maxLength = 40}) {
                                                 onTap: () async {
                                                  FilePickerResult? result = await FilePicker.platform.pickFiles(
                                                     type: FileType.custom,
-                                                    allowedExtensions: ['mp3', 'wav', 'aiff'], // нужные тебе форматы
+                                                    allowedExtensions: ['mp3', 'wav', 'aiff'],
                                                   );
 
                                                   if (result != null && result.files.single.path != null) {
+                                                    temp.filePath = result.files.single.path!;
+                                                    Duration? d = await temp.player.setFilePath(temp.filePath);
                                                     setState(() {
-                                                      temp.filePath = result.files.single.path!;
+                                                      temp.startTime = Duration.zero;
+                                                      temp.stopTime = d ?? Duration.zero;
+                                                      _startController.text = formatDuration(temp.startTime);
+                                                      _endController.text = formatDuration(temp.stopTime);
                                                     });
                                                   }
                                                 },
@@ -550,7 +579,7 @@ String shortenPath(String fullPath, {int maxLength = 40}) {
                                       ),
                                       Expanded(
                                         key: Key('Play_Mode_frame'),
-                                        
+
                                         child: Container(
                                           width: double.infinity,
                                           height: double.infinity,
@@ -561,88 +590,109 @@ String shortenPath(String fullPath, {int maxLength = 40}) {
                                             crossAxisAlignment: CrossAxisAlignment.start,
                                             spacing: 10,
                                             children: [
-                                              Container(
-                                                key: Key('Playstop_btn_frame'),
-                                                height: double.infinity,
-                                                padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 6),
-                                                clipBehavior: Clip.antiAlias,
-                                                decoration: ShapeDecoration(
-                                                  color: const Color(0xFFD9D9D9),
-                                                  shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(4)),
-                                                ),
-                                                child: Column(
-                                                  mainAxisSize: MainAxisSize.min,
-                                                  mainAxisAlignment: MainAxisAlignment.end,
-                                                  crossAxisAlignment: CrossAxisAlignment.center,
-                                                  spacing: 17,
-                                                  children: [
-                                                    Text(
-                                                      'Play/Stop',
-                                                      textAlign: TextAlign.center,
-                                                      style: TextStyle(
-                                                        color: Colors.black,
-                                                        fontSize: 16,
-                                                        fontFamily: 'Inter',
-                                                        fontWeight: FontWeight.w500,
+                                              GestureDetector(
+                                                onTap: () {
+                                                  setState(() {
+                                                    temp.playMode = PlayMode.playStop;
+                                                  });
+                                                },
+                                                child: Container(
+                                                  key: Key('Playstop_btn_frame'),
+                                                  height: double.infinity,
+                                                  padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 6),
+                                                  clipBehavior: Clip.antiAlias,
+                                                  decoration: ShapeDecoration(
+                                                    color: temp.playMode == PlayMode.playStop ? const Color(0xFFB0B0B0) : const Color(0xFFD9D9D9),
+                                                    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(4)),
+                                                  ),
+                                                  child: Column(
+                                                    mainAxisSize: MainAxisSize.min,
+                                                    mainAxisAlignment: MainAxisAlignment.end,
+                                                    crossAxisAlignment: CrossAxisAlignment.center,
+                                                    spacing: 17,
+                                                    children: [
+                                                      const Text(
+                                                        'Play/Stop',
+                                                        textAlign: TextAlign.center,
+                                                        style: TextStyle(
+                                                          color: Colors.black,
+                                                          fontSize: 16,
+                                                          fontFamily: 'Inter',
+                                                          fontWeight: FontWeight.w500,
+                                                        ),
                                                       ),
-                                                    ),
-                                                  ],
+                                                    ],
+                                                  ),
                                                 ),
                                               ),
-                                              Container(
-                                                key: Key('Playpause_btn_frame'),
-                                                height: double.infinity,
-                                                padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 6),
-                                                clipBehavior: Clip.antiAlias,
-                                                decoration: ShapeDecoration(
-                                                  color: const Color(0xFFD9D9D9),
-                                                  shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(4)),
-                                                ),
-                                                child: Column(
-                                                  mainAxisSize: MainAxisSize.min,
-                                                  mainAxisAlignment: MainAxisAlignment.end,
-                                                  crossAxisAlignment: CrossAxisAlignment.center,
-                                                  spacing: 17,
-                                                  children: [
-                                                    Text(
-                                                      'Play/Pause',
-                                                      textAlign: TextAlign.center,
-                                                      style: TextStyle(
-                                                        color: Colors.black,
-                                                        fontSize: 16,
-                                                        fontFamily: 'Inter',
-                                                        fontWeight: FontWeight.w500,
+                                              GestureDetector(
+                                                onTap: () {
+                                                  setState(() {
+                                                    temp.playMode = PlayMode.playPause;
+                                                  });
+                                                },
+                                                child: Container(
+                                                  key: Key('Playpause_btn_frame'),
+                                                  height: double.infinity,
+                                                  padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 6),
+                                                  clipBehavior: Clip.antiAlias,
+                                                  decoration: ShapeDecoration(
+                                                    color: temp.playMode == PlayMode.playPause ? const Color(0xFFB0B0B0) : const Color(0xFFD9D9D9),
+                                                    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(4)),
+                                                  ),
+                                                  child: Column(
+                                                    mainAxisSize: MainAxisSize.min,
+                                                    mainAxisAlignment: MainAxisAlignment.end,
+                                                    crossAxisAlignment: CrossAxisAlignment.center,
+                                                    spacing: 17,
+                                                    children: [
+                                                      const Text(
+                                                        'Play/Pause',
+                                                        textAlign: TextAlign.center,
+                                                        style: TextStyle(
+                                                          color: Colors.black,
+                                                          fontSize: 16,
+                                                          fontFamily: 'Inter',
+                                                          fontWeight: FontWeight.w500,
+                                                        ),
                                                       ),
-                                                    ),
-                                                  ],
+                                                    ],
+                                                  ),
                                                 ),
                                               ),
-                                              Container(
-                                                key: Key('Retrigger_btn_frame'),
-                                                height: double.infinity,
-                                                padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 6),
-                                                clipBehavior: Clip.antiAlias,
-                                                decoration: ShapeDecoration(
-                                                  color: const Color(0xFFD9D9D9),
-                                                  shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(4)),
-                                                ),
-                                                child: Column(
-                                                  mainAxisSize: MainAxisSize.min,
-                                                  mainAxisAlignment: MainAxisAlignment.end,
-                                                  crossAxisAlignment: CrossAxisAlignment.center,
-                                                  spacing: 17,
-                                                  children: [
-                                                    Text(
-                                                      'Retrigger',
-                                                      textAlign: TextAlign.center,
-                                                      style: TextStyle(
-                                                        color: Colors.black,
-                                                        fontSize: 16,
-                                                        fontFamily: 'Inter',
-                                                        fontWeight: FontWeight.w500,
+                                              GestureDetector(
+                                                onTap: () {
+                                                  setState(() {
+                                                    temp.playMode = PlayMode.retrigger;
+                                                  });
+                                                },
+                                                child: Container(
+                                                  key: Key('Retrigger_btn_frame'),
+                                                  height: double.infinity,
+                                                  padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 6),
+                                                  clipBehavior: Clip.antiAlias,
+                                                  decoration: ShapeDecoration(
+                                                    color: temp.playMode == PlayMode.retrigger ? const Color(0xFFB0B0B0) : const Color(0xFFD9D9D9),
+                                                    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(4)),
+                                                  ),
+                                                  child: Column(
+                                                    mainAxisSize: MainAxisSize.min,
+                                                    mainAxisAlignment: MainAxisAlignment.end,
+                                                    crossAxisAlignment: CrossAxisAlignment.center,
+                                                    spacing: 17,
+                                                    children: [
+                                                      const Text(
+                                                        'Retrigger',
+                                                        textAlign: TextAlign.center,
+                                                        style: TextStyle(
+                                                          color: Colors.black,
+                                                          fontSize: 16,
+                                                          fontFamily: 'Inter',
+                                                          fontWeight: FontWeight.w500,
+                                                        ),
                                                       ),
-                                                    ),
-                                                  ],
+                                                    ],
+                                                  ),
                                                 ),
                                               ),
                                             ],
@@ -919,6 +969,7 @@ String shortenPath(String fullPath, {int maxLength = 40}) {
                                             children: [
                                               Container(
                                                 key: Key('Start_textedit_frame'),
+                                                width: 100,
                                                 height: double.infinity,
                                                 padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 7),
                                                 clipBehavior: Clip.antiAlias,
@@ -926,27 +977,22 @@ String shortenPath(String fullPath, {int maxLength = 40}) {
                                                   color: const Color(0xFFD9D9D9),
                                                   shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(4)),
                                                 ),
-                                                child: Row(
-                                                  mainAxisSize: MainAxisSize.min,
-                                                  mainAxisAlignment: MainAxisAlignment.center,
-                                                  crossAxisAlignment: CrossAxisAlignment.end,
-                                                  spacing: 10,
-                                                  children: [
-                                                    Text(
-                                                      '00:00:00:00',
-                                                      textAlign: TextAlign.center,
-                                                      style: TextStyle(
-                                                        color: Colors.black,
-                                                        fontSize: 20,
-                                                        fontFamily: 'Inter',
-                                                        fontWeight: FontWeight.w500,
-                                                      ),
-                                                    ),
-                                                  ],
+                                                child: TextField(
+                                                  controller: _startController,
+                                                  inputFormatters: [timeFormatter],
+                                                  keyboardType: TextInputType.number,
+                                                  decoration: const InputDecoration(border: InputBorder.none),
+                                                  style: const TextStyle(
+                                                    color: Colors.black,
+                                                    fontSize: 20,
+                                                    fontFamily: 'Inter',
+                                                    fontWeight: FontWeight.w500,
+                                                  ),
                                                 ),
                                               ),
                                               Container(
                                                 key: Key('End_textedit_frame'),
+                                                width: 100,
                                                 height: double.infinity,
                                                 padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 7),
                                                 clipBehavior: Clip.antiAlias,
@@ -954,23 +1000,17 @@ String shortenPath(String fullPath, {int maxLength = 40}) {
                                                   color: const Color(0xFFD9D9D9),
                                                   shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(4)),
                                                 ),
-                                                child: Row(
-                                                  mainAxisSize: MainAxisSize.min,
-                                                  mainAxisAlignment: MainAxisAlignment.center,
-                                                  crossAxisAlignment: CrossAxisAlignment.end,
-                                                  spacing: 10,
-                                                  children: [
-                                                    Text(
-                                                      '00:15:24:00',
-                                                      textAlign: TextAlign.center,
-                                                      style: TextStyle(
-                                                        color: Colors.black,
-                                                        fontSize: 20,
-                                                        fontFamily: 'Inter',
-                                                        fontWeight: FontWeight.w500,
-                                                      ),
-                                                    ),
-                                                  ],
+                                                child: TextField(
+                                                  controller: _endController,
+                                                  inputFormatters: [timeFormatter],
+                                                  keyboardType: TextInputType.number,
+                                                  decoration: const InputDecoration(border: InputBorder.none),
+                                                  style: const TextStyle(
+                                                    color: Colors.black,
+                                                    fontSize: 20,
+                                                    fontFamily: 'Inter',
+                                                    fontWeight: FontWeight.w500,
+                                                  ),
                                                 ),
                                               ),
                                               Container(
@@ -1001,32 +1041,43 @@ String shortenPath(String fullPath, {int maxLength = 40}) {
                                                   ],
                                                 ),
                                               ),
-                                              Container(
-                                                key: Key('Reset_btn_frame'),
-                                                height: double.infinity,
-                                                padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 7),
-                                                clipBehavior: Clip.antiAlias,
-                                                decoration: ShapeDecoration(
-                                                  color: const Color(0xFFD9D9D9),
-                                                  shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(4)),
-                                                ),
-                                                child: Row(
-                                                  mainAxisSize: MainAxisSize.min,
-                                                  mainAxisAlignment: MainAxisAlignment.center,
-                                                  crossAxisAlignment: CrossAxisAlignment.end,
-                                                  spacing: 10,
-                                                  children: [
-                                                    Text(
-                                                      'Reset',
-                                                      textAlign: TextAlign.center,
-                                                      style: TextStyle(
-                                                        color: Colors.black,
-                                                        fontSize: 20,
-                                                        fontFamily: 'Inter',
-                                                        fontWeight: FontWeight.w500,
+                                              GestureDetector(
+                                                onTap: () {
+                                                  final duration = temp.player.duration ?? Duration.zero;
+                                                  setState(() {
+                                                    temp.startTime = Duration.zero;
+                                                    temp.stopTime = duration;
+                                                    _startController.text = formatDuration(temp.startTime);
+                                                    _endController.text = formatDuration(temp.stopTime);
+                                                  });
+                                                },
+                                                child: Container(
+                                                  key: Key('Reset_btn_frame'),
+                                                  height: double.infinity,
+                                                  padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 7),
+                                                  clipBehavior: Clip.antiAlias,
+                                                  decoration: ShapeDecoration(
+                                                    color: const Color(0xFFD9D9D9),
+                                                    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(4)),
+                                                  ),
+                                                  child: Row(
+                                                    mainAxisSize: MainAxisSize.min,
+                                                    mainAxisAlignment: MainAxisAlignment.center,
+                                                    crossAxisAlignment: CrossAxisAlignment.end,
+                                                    spacing: 10,
+                                                    children: const [
+                                                      Text(
+                                                        'Reset',
+                                                        textAlign: TextAlign.center,
+                                                        style: TextStyle(
+                                                          color: Colors.black,
+                                                          fontSize: 20,
+                                                          fontFamily: 'Inter',
+                                                          fontWeight: FontWeight.w500,
+                                                        ),
                                                       ),
-                                                    ),
-                                                  ],
+                                                    ],
+                                                  ),
                                                 ),
                                               ),
                                             ],
@@ -1057,6 +1108,8 @@ String shortenPath(String fullPath, {int maxLength = 40}) {
                           children: [
                             GestureDetector(
                               onTap: () {
+                                temp.startTime = parseDuration(_startController.text);
+                                temp.stopTime = parseDuration(_endController.text);
                                 context.read<ChannelBankModel>().updateChannel(widget.index, temp);
                                 Navigator.of(context).pop();
                               },

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,6 +32,8 @@ dependencies:
     sdk: flutter
   provider: ^6.1.2
   file_picker: ^6.1.1
+  just_audio: ^0.9.36
+  mask_text_input_formatter: ^2.4.0
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8


### PR DESCRIPTION
## Summary
- allow start/end time editing in settings using masked input
- preload audio duration on file selection and reset start/end
- reset start/end time with reset button
- persist range values on save
- show start/stop times in channel UI and clip playback
- add mask input dependency

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846b59bf11c8331aaa821fc0c0ba488