### PR TITLE
Reset audio source after saving clip times

### DIFF
--- a/lib/settings.dart
+++ b/lib/settings.dart
@@ -1147,9 +1147,11 @@ Duration parseDuration(String text) {
                           spacing: 17,
                           children: [
                             GestureDetector(
-                              onTap: () {
+                              onTap: () async {
                                 temp.startTime = parseDuration(_startController.text);
                                 temp.stopTime = parseDuration(_endController.text);
+                                await temp.player.stop();
+                                await temp.player.clearAudioSources();
                                 context.read<ChannelBankModel>().updateChannel(widget.index, temp);
                                 Navigator.of(context).pop();
                               },


### PR DESCRIPTION
## Summary
- ensure audio source reloads after saving start/end times

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846da3bf9e48331a88cfa7579d568e9