### PR TITLE
Rewrite playback logic

### DIFF
--- a/lib/ChannelAudioController.dart
+++ b/lib/ChannelAudioController.dart
@@ -3,162 +3,156 @@ import 'package:flutter/material.dart';
 import 'dart:async';
 import 'models/channel_strip_model.dart';
 
+/// Controller that manages playback for a single [ChannelStripModel].
+/// It supports fade-in, fade-out and three play modes.
 class ChannelAudioController {
   final AudioPlayer player;
   final ChannelStripModel model;
 
+  /// Timers used for fade effects.
   Timer? _fadeInTimer;
   Timer? _fadeOutTimer;
-  Timer? _fadeOutDelayTimer;
-  bool isCompleted = false;
+
+  /// Whether the clip finished playing to the end.
+  bool _completed = false;
 
   ChannelAudioController(this.model) : player = AudioPlayer() {
+    // When playback reaches the end of the clip we pause and reset so the
+    // next press starts from the beginning of the defined range.
     player.playerStateStream.listen((state) async {
       if (state.processingState == ProcessingState.completed) {
-        isCompleted = true;
-        await player.seek(model.startTime);
+        _completed = true;
+        await player.seek(Duration.zero);
         await player.pause();
       }
     });
   }
 
-  Future<void> loadSource() async {
+  /// Load the current file with clipping applied.
+  Future<void> _loadSource() async {
+    final endTime =
+        (model.stopTime > Duration.zero && model.stopTime > model.startTime)
+            ? model.stopTime
+            : null;
+
     await player.setAudioSource(
       ClippingAudioSource(
         start: model.startTime,
-        end: model.stopTime,
+        end: endTime,
         child: AudioSource.file(model.filePath),
       ),
       initialPosition: Duration.zero,
     );
   }
 
-  Future<void> toggle() async {
-    cancelFadeTimers();
-
-    switch (model.playMode) {
-      case PlayMode.playStop:
-        if (player.playing) {
-          await fadeOutAndStop();
-        } else {
-          if (isCompleted) {
-            await player.seek(model.startTime);
-            isCompleted = false;
-          } else if (player.audioSource == null) {
-            await loadSource();
-            await player.seek(model.startTime);
-          }
-          await player.setVolume(1.0); // Reset volume before fade-in
-          await player.setVolume(model.fadeInSeconds > 0 ? 0.0 : 1.0);
-          await player.play();
-          if (model.fadeInSeconds > 0) applyFadeInOut();
-        }
-        break;
-
-      case PlayMode.playPause:
-        if (player.playing) {
-          await fadeOutAndStop();
-        } else {
-          if (isCompleted) {
-            await player.seek(model.startTime);
-            isCompleted = false;
-          } else if (player.audioSource == null) {
-            await loadSource();
-            await player.seek(model.startTime);
-          }
-          await player.setVolume(1.0); // Reset volume before fade-in
-          await player.setVolume(model.fadeInSeconds > 0 ? 0.0 : 1.0);
-          await player.play();
-          if (model.fadeInSeconds > 0) applyFadeInOut();
-        }
-        break;
-
-      case PlayMode.retrigger:
-        await player.stop();
-        await loadSource();
-        await player.seek(model.startTime);
-        await player.setVolume(1.0); // Reset volume before fade-in
-        await player.setVolume(model.fadeInSeconds > 0 ? 0.0 : 1.0);
-        await player.play();
-        if (model.fadeInSeconds > 0) applyFadeInOut();
-        isCompleted = false;
-        break;
+  /// Start playback from the beginning of the clip with optional fade-in.
+  Future<void> _startPlayback() async {
+    await _loadSource();
+    await player.seek(Duration.zero);
+    final fadeInDur =
+        Duration(milliseconds: (model.fadeInSeconds * 1000).round());
+    if (fadeInDur > Duration.zero) {
+      await player.setVolume(0.0);
+      await player.play();
+      _startFadeIn(fadeInDur);
+    } else {
+      await player.setVolume(1.0);
+      await player.play();
     }
+    _completed = false;
   }
 
-  Future<void> fadeOutAndStop() async {
-    final fadeOut = Duration(milliseconds: (model.fadeOutSeconds * 1000).round());
-
-    if (fadeOut <= Duration.zero) {
-      await player.setVolume(1.0);
-      await player.stop();
-      await player.seek(model.startTime);
-      return;
-    }
-
-    int ms = 0;
-    _fadeOutTimer = Timer.periodic(const Duration(milliseconds: 10), (timer) async {
-      ms += 10;
-      if (ms >= fadeOut.inMilliseconds) {
+  /// Begin a fade-in over [duration].
+  void _startFadeIn(Duration duration) {
+    int elapsed = 0;
+    _fadeInTimer = Timer.periodic(const Duration(milliseconds: 20), (timer) {
+      elapsed += 20;
+      final vol = (elapsed / duration.inMilliseconds).clamp(0.0, 1.0);
+      player.setVolume(vol);
+      if (elapsed >= duration.inMilliseconds) {
         player.setVolume(1.0);
         timer.cancel();
-        await player.stop();
-        await player.seek(model.startTime);
-      } else {
-        player.setVolume((1.0 - (ms / fadeOut.inMilliseconds)).clamp(0.0, 1.0));
+        _fadeInTimer = null;
       }
     });
   }
 
-  Future<void> applyFadeInOut() async {
-    final fadeIn = Duration(milliseconds: (model.fadeInSeconds * 1000).round());
-    final fadeOut = Duration(milliseconds: (model.fadeOutSeconds * 1000).round());
-    final total = model.stopTime - model.startTime;
+  /// Fade out the current playback and then either stop or pause.
+  Future<void> _fadeOutAndFinish({required bool pause}) async {
+    final fadeOutDur =
+        Duration(milliseconds: (model.fadeOutSeconds * 1000).round());
+    final startVol = player.volume;
 
-    if (fadeIn > Duration.zero) {
-      int ms = 0;
-      _fadeInTimer = Timer.periodic(const Duration(milliseconds: 10), (timer) {
-        ms += 10;
-        final newVol = (ms / fadeIn.inMilliseconds).clamp(0.0, 1.0);
-        player.setVolume(newVol);
-        if (ms >= fadeIn.inMilliseconds) {
-          player.setVolume(1.0);
-          timer.cancel();
+    if (fadeOutDur <= Duration.zero) {
+      if (pause) {
+        await player.pause();
+      } else {
+        await player.stop();
+      }
+      await player.seek(Duration.zero);
+      await player.setVolume(1.0);
+      return;
+    }
+
+    int elapsed = 0;
+    final completer = Completer<void>();
+    _fadeOutTimer = Timer.periodic(const Duration(milliseconds: 20), (timer) async {
+      elapsed += 20;
+      final progress = elapsed / fadeOutDur.inMilliseconds;
+      final vol = (startVol * (1.0 - progress)).clamp(0.0, 1.0);
+      player.setVolume(vol);
+      if (elapsed >= fadeOutDur.inMilliseconds) {
+        timer.cancel();
+        if (pause) {
+          await player.pause();
+        } else {
+          await player.stop();
         }
-      });
-    } else {
-      player.setVolume(1.0);
-    }
-
-    if (fadeOut > Duration.zero && total > fadeOut) {
-      final fadeOutStart = total - fadeOut;
-
-      _fadeOutDelayTimer = Timer(fadeOutStart, () {
-        int ms = 0;
-        _fadeOutTimer = Timer.periodic(const Duration(milliseconds: 10), (timer) {
-          ms += 10;
-          player.setVolume((1.0 - (ms / fadeOut.inMilliseconds)).clamp(0.0, 1.0));
-          if (ms >= fadeOut.inMilliseconds) {
-            player.setVolume(0.0);
-            timer.cancel();
-          }
-        });
-      });
-    }
+        await player.seek(Duration.zero);
+        await player.setVolume(1.0);
+        _fadeOutTimer = null;
+        completer.complete();
+      }
+    });
+    await completer.future;
   }
 
-  void cancelFadeTimers() {
+  /// Cancel any running fade timers.
+  void _cancelFades() {
     _fadeInTimer?.cancel();
     _fadeOutTimer?.cancel();
-    _fadeOutDelayTimer?.cancel();
     _fadeInTimer = null;
     _fadeOutTimer = null;
-    _fadeOutDelayTimer = null;
-    player.setVolume(1.0);
+  }
+
+  /// Toggle playback according to the selected play mode.
+  Future<void> toggle() async {
+    _cancelFades();
+
+    if (player.playing) {
+      switch (model.playMode) {
+        case PlayMode.playStop:
+          await _fadeOutAndFinish(pause: false);
+          break;
+        case PlayMode.playPause:
+          await _fadeOutAndFinish(pause: true);
+          break;
+        case PlayMode.retrigger:
+          await player.stop();
+          await _startPlayback();
+          break;
+      }
+    } else {
+      if (_completed) {
+        await player.seek(Duration.zero);
+        _completed = false;
+      }
+      await _startPlayback();
+    }
   }
 
   Future<void> dispose() async {
-    cancelFadeTimers();
+    _cancelFades();
     await player.dispose();
   }
 }


### PR DESCRIPTION
## Summary
- overhaul ChannelAudioController
- implement new play/stop, play/pause and retrigger logic
- rewrite fade-in and fade-out handling

## Testing
- `flutter test` *(fails: flutter not found)*

------
https://chatgpt.com/codex/tasks/task_e_684adec5fbe4833187e14a2043b1984c